### PR TITLE
Upgrade Hive version (3.1.0 -> 3.1.2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Matteo Capitanio <matteo.capitanio@gmail.com>
 
 USER root
 
-ENV HIVE_VER 3.1.0
+ENV HIVE_VER 3.1.2
 ENV TEZ_VER 0.9.1
 
 ENV HIVE_HOME /opt/hive


### PR DESCRIPTION
It appears `3.1.0` is no longer hosted on http://it.apache.contactlab.it, as I ran into the following error message when running `docker-compose up` command.

```
Step 17/28 : RUN wget http://it.apache.contactlab.it/hive/hive-$HIVE_VER/apache-hive-$HIVE_VER-bin.tar.gz
 ---> Running in be07e9892caa
--2019-10-07 06:12:18--  http://it.apache.contactlab.it/hive/hive-3.1.0/apache-hive-3.1.0-bin.tar.gz
Resolving it.apache.contactlab.it (it.apache.contactlab.it)... 185.34.86.124
Connecting to it.apache.contactlab.it (it.apache.contactlab.it)|185.34.86.124|:80... connected.
HTTP request sent, awaiting response... 404 Not Found
2019-10-07 06:12:19 ERROR 404: Not Found.

ERROR: Service 'hive' failed to build: The command '/bin/sh -c wget http://it.apache.contactlab.it/hive/hive-$HIVE_VER/apache-hive-$HIVE_VER-bin.tar.gz' returned a non-zero code: 8
```

However, `3.1.2` is being hosted and it would be great if we could upgrade the version accordingly.